### PR TITLE
refactor: update ClientBuilder to return a JoinHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "env_logger",
  "futures-util",
  "log",
+ "pin-project-lite",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rustls = ["reqwest/rustls-tls", "tokio-tungstenite/rustls-tls-webpki-roots"]
 bytes = "1.10.1"
 futures-util = "0.3.31"
 log = { version = "0.4.26", features = ["kv"] }
+pin-project-lite = "0.2.16"
 reqwest = { version = "0.12.12", features = [
 	"json",
 	"multipart",

--- a/examples/text_to_image.rs
+++ b/examples/text_to_image.rs
@@ -136,7 +136,7 @@ async fn main() {
         .filter_level(log::LevelFilter::Debug)
         .init();
 
-    let (client, mut stream) = ClientBuilder::new("http://localhost:8188")
+    let (client, mut stream, handle) = ClientBuilder::new("http://localhost:8188")
         .build()
         .await
         .unwrap();
@@ -200,4 +200,6 @@ async fn main() {
             }
         }
     }
+
+    handle.abort();
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use comfyui_client::{ClientBuilder, ComfyUIClient, EventStream};
 use std::sync::Once;
+use tokio::task::JoinHandle;
 
 pub fn setup() {
     static START: Once = Once::new();
@@ -10,7 +11,7 @@ pub fn setup() {
     });
 }
 
-pub async fn build_client() -> (ComfyUIClient, EventStream) {
+pub async fn build_client() -> (ComfyUIClient, EventStream, JoinHandle<()>) {
     ClientBuilder::new("http://localhost:8188")
         .build()
         .await

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,14 +8,15 @@ use tokio_stream::StreamExt;
 #[tokio::test]
 async fn test_get_prompt() {
     common::setup();
-    let (client, _) = common::build_client().await;
+    let (client, _, handle) = common::build_client().await;
     client.get_prompt().await.unwrap();
+    handle.abort();
 }
 
 #[tokio::test]
 async fn test_integration() {
     common::setup();
-    let (client, mut stream) = common::build_client().await;
+    let (client, mut stream, handle) = common::build_client().await;
 
     let file = File::open("./tests/data/cat.webp").await.unwrap();
     let file_info = FileInfo {
@@ -64,4 +65,6 @@ async fn test_integration() {
     let image2_buf = client.get_view(&image).await.unwrap();
 
     assert_eq!(image_buf, image2_buf);
+
+    handle.abort();
 }


### PR DESCRIPTION
I refactored it this way to allow `EventStream` to use `SteamExt`'s cool methods, such as map, filter, etc., while allowing users to manipulate Handles to increase flexibility